### PR TITLE
Update d3 charts to have a class prefix

### DIFF
--- a/docs/INF0456.html
+++ b/docs/INF0456.html
@@ -53,84 +53,84 @@ Choose a question to see data from the student assessment:<br />
             <div id="howdoyouratethecourseingeneral" class="question">
                 <h4>Question: How do you rate the course in general?</h4>
                 <p>Average answer: Very good</p>
-                <div id="chart_howdoyouratethecourseingeneral" class="chart"></div>
+                <div id="chart_howdoyouratethecourseingeneral" class="d3kk-chart"></div>
             </div>
         
 
             <div id="howdoyouratethelevelofthecourse" class="question">
                 <h4>Question: How do you rate the level of the course?</h4>
                 <p>Average answer: Easy</p>
-                <div id="chart_howdoyouratethelevelofthecourse" class="chart"></div>
+                <div id="chart_howdoyouratethelevelofthecourse" class="d3kk-chart"></div>
             </div>
         
 
             <div id="howdoyouratetheworkloadinproportiontothenumberofcreditsachieved" class="question">
                 <h4>Question: How do you rate the work load in proportion to the number of credits achieved?</h4>
                 <p>Average answer: OK</p>
-                <div id="chart_howdoyouratetheworkloadinproportiontothenumberofcreditsachieved" class="chart"></div>
+                <div id="chart_howdoyouratetheworkloadinproportiontothenumberofcreditsachieved" class="d3kk-chart"></div>
             </div>
         
 
             <div id="thequalityofthelectures" class="question">
                 <h4>Question: The quality of the lectures?</h4>
                 <p>Average answer: Very good</p>
-                <div id="chart_thequalityofthelectures" class="chart"></div>
+                <div id="chart_thequalityofthelectures" class="d3kk-chart"></div>
             </div>
         
 
             <div id="thelecturesrelevanceandusefulnessinregardtorelayingwhatyouneedtolearn" class="question">
                 <h4>Question: The lectures' relevance and usefulness in regard to relaying what you need to learn?</h4>
                 <p>Average answer: Not that good</p>
-                <div id="chart_thelecturesrelevanceandusefulnessinregardtorelayingwhatyouneedtolearn" class="chart"></div>
+                <div id="chart_thelecturesrelevanceandusefulnessinregardtorelayingwhatyouneedtolearn" class="d3kk-chart"></div>
             </div>
         
 
             <div id="thequalityofthegrouptuitionasawhole" class="question">
                 <h4>Question: The quality of the group tuition as a whole?</h4>
                 <p>Average answer: Good</p>
-                <div id="chart_thequalityofthegrouptuitionasawhole" class="chart"></div>
+                <div id="chart_thequalityofthegrouptuitionasawhole" class="d3kk-chart"></div>
             </div>
         
 
             <div id="inwhatdegreedoesgrouptuitionandweeklyassignmentsgiveyoupracticalskillsandthepossibilitytomakeuseofthetheoryathand" class="question">
                 <h4>Question: In what degree does group tuition and weekly assignments give you practical skills and the possibility to make use of the theory at hand?</h4>
                 <p>Average answer: Good</p>
-                <div id="chart_inwhatdegreedoesgrouptuitionandweeklyassignmentsgiveyoupracticalskillsandthepossibilitytomakeuseofthetheoryathand" class="chart"></div>
+                <div id="chart_inwhatdegreedoesgrouptuitionandweeklyassignmentsgiveyoupracticalskillsandthepossibilitytomakeuseofthetheoryathand" class="d3kk-chart"></div>
             </div>
         
 
             <div id="arethecurriculumandlearningoutcomesofthecoursesufficientlydefined" class="question">
                 <h4>Question: Are the curriculum and learning outcomes of the course sufficiently defined?</h4>
                 <p>Average answer: Good</p>
-                <div id="chart_arethecurriculumandlearningoutcomesofthecoursesufficientlydefined" class="chart"></div>
+                <div id="chart_arethecurriculumandlearningoutcomesofthecoursesufficientlydefined" class="d3kk-chart"></div>
             </div>
         
 
             <div id="howdoyouratethecoursematerialusedtextbooketc" class="question">
                 <h4>Question: How do you rate the course material used (text book etc.)?</h4>
                 <p>Average answer: Not that good</p>
-                <div id="chart_howdoyouratethecoursematerialusedtextbooketc" class="chart"></div>
+                <div id="chart_howdoyouratethecoursematerialusedtextbooketc" class="d3kk-chart"></div>
             </div>
         
 
             <div id="howdoyouratethedifficultyleveloftheobligatoryassignments" class="question">
                 <h4>Question: How do you rate the difficulty level of the obligatory assignments?</h4>
                 <p>Average answer: OK</p>
-                <div id="chart_howdoyouratethedifficultyleveloftheobligatoryassignments" class="chart"></div>
+                <div id="chart_howdoyouratethedifficultyleveloftheobligatoryassignments" class="d3kk-chart"></div>
             </div>
         
 
             <div id="whatisyouropinioninregardtothenumberofobligatoryassignments" class="question">
                 <h4>Question: What is your opinion in regard to the number of obligatory assignments?</h4>
                 <p>Average answer: High</p>
-                <div id="chart_whatisyouropinioninregardtothenumberofobligatoryassignments" class="chart"></div>
+                <div id="chart_whatisyouropinioninregardtothenumberofobligatoryassignments" class="d3kk-chart"></div>
             </div>
         
 
             <div id="howdoyouratethedifficultylevelofthefinalexamination" class="question">
                 <h4>Question: How do you rate the difficulty level of the final examination?</h4>
                 <p>Average answer: Too high</p>
-                <div id="chart_howdoyouratethedifficultylevelofthefinalexamination" class="chart"></div>
+                <div id="chart_howdoyouratethedifficultylevelofthefinalexamination" class="d3kk-chart"></div>
             </div>
         
 <h2>Summary:</h2>
@@ -155,7 +155,7 @@ Choose a question to see data from the student assessment:<br />
         <div class="vrtx-box-content">
           <p><b>Generell assessment: </b><em>Very good</em></p>
           <p><b>Semester: </b>V2016</p>
-          <p><b>Respondents:</b> 3 of 6 (50.0%)</p>
+          <p><b>Respondents:</b> 3 of 5 (60.0%)</p>
           <p><b>Data: </b><a href="stats/INF0456.js">JSON</a></p>
         </div>
       </div>

--- a/docs/d3kk.css
+++ b/docs/d3kk.css
@@ -1,16 +1,16 @@
-.chart {
+.d3kk-chart {
   font-family: sans-serif;
   cursor: pointer;
 }
 
-.axis path,
-.axis line {
+.d3kk-axis path,
+.d3kk-axis line {
   fill: none;
   stroke: black;
   shape-rendering: crispEdges;
 }
 
-.tooltip {
+.d3kk-tooltip {
   position: absolute;
   padding: 3px;
   border-radius: 2px;

--- a/docs/d3kk.js
+++ b/docs/d3kk.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var tooltip = d3.select("body").append("div").attr("class", "tooltip");
+var tooltip = d3.select("body").append("div").attr("class", "d3kk-tooltip");
 
 function show_tooltip(message) {
     tooltip.html(message).style("left", d3.event.pageX + 3 + "px").style("top", d3.event.pageY - 28 + "px").style("opacity", 1);
@@ -32,7 +32,7 @@ function insert_chart(target_selector, data, colors) {
     var expanded = false;
 
     svg.selectAll("rect").data(data).enter().append("rect").attr("class", function (d, i) {
-        return "rect-" + i;
+        return "d3kk-rect-" + i;
     }).attr("width", function (d) {
         return scale(d.value);
     }).attr("height", height).attr("x", function (d) {
@@ -56,7 +56,7 @@ function insert_chart(target_selector, data, colors) {
                 var cury = 0;
 
                 var _loop = function _loop(i) {
-                    svg.select(".rect-" + i).transition().duration(100).attr("y", cury).transition().duration(100).attr("x", col_base);
+                    svg.select(".d3kk-rect-" + i).transition().duration(100).attr("y", cury).transition().duration(100).attr("x", col_base);
 
                     var font_size = 16;
                     var label_base = col_base - 5;
@@ -77,20 +77,18 @@ function insert_chart(target_selector, data, colors) {
                     var col_width = scale(data[i].value);
 
                     if (col_width + col_base > width) {
-                        (function () {
-                            col_width = width - col_base;
+                        col_width = width - col_base;
 
-                            // The following is just a roundabout way to draw a zig-zag marker
-                            // on the column, to indicate that it has been truncated.
-                            var yScale = d3.scale.linear().domain([0, 100]).range([0, height]);
-                            var area = d3.svg.line().x(function (d) {
-                                return d.x / 3 + (col_base + col_width / 2);
-                            }).y(function (d) {
-                                return cury + yScale(d.y);
-                            });
+                        // The following is just a roundabout way to draw a zig-zag marker
+                        // on the column, to indicate that it has been truncated.
+                        var yScale = d3.scale.linear().domain([0, 100]).range([0, height]);
+                        var area = d3.svg.line().x(function (d) {
+                            return d.x / 3 + (col_base + col_width / 2);
+                        }).y(function (d) {
+                            return cury + yScale(d.y);
+                        });
 
-                            svg.append('path').datum([{ 'x': 0, 'y': 0 }, { 'x': 25, 'y': 33 }, { 'x': 0, 'y': 66 }, { 'x': 25, 'y': 100 }, { 'x': 50, 'y': 100 }, { 'x': 25, 'y': 66 }, { 'x': 50, 'y': 33 }, { 'x': 25, 'y': 0 }]).attr('fill', 'white').transition().delay(200).attr('d', area);
-                        })();
+                        svg.append('path').datum([{ 'x': 0, 'y': 0 }, { 'x': 25, 'y': 33 }, { 'x': 0, 'y': 66 }, { 'x': 25, 'y': 100 }, { 'x': 50, 'y': 100 }, { 'x': 25, 'y': 66 }, { 'x': 50, 'y': 33 }, { 'x': 25, 'y': 0 }]).attr('fill', 'white').transition().delay(200).attr('d', area);
                     }
 
                     svg.append("text").transition().delay(200).attr("x", col_base + (labelinside ? col_width - 5 : col_width + 5)).attr("y", cury + height / 2).attr("dominant-baseline", "middle").attr("text-anchor", labelinside ? "end" : "start").text(Math.round(percentage(data[i].value)) + "%");
@@ -107,21 +105,19 @@ function insert_chart(target_selector, data, colors) {
                 expanded = true;
             })();
         } else {
-            (function () {
-                svg.selectAll("text").remove();
-                svg.selectAll("path").remove();
+            svg.selectAll("text").remove();
+            svg.selectAll("path").remove();
 
-                var curx = 0;
-                svg.selectAll("rect").transition().duration(100).attr("x", function (d) {
-                    var ret = curx;
-                    curx += scale(d.value);
-                    return ret;
-                }).transition().duration(100).attr("y", 0);
+            var _curx = 0;
+            svg.selectAll("rect").transition().duration(100).attr("x", function (d) {
+                var ret = _curx;
+                _curx += scale(d.value);
+                return ret;
+            }).transition().duration(100).attr("y", 0);
 
-                svg.transition().delay(100).duration(100).attr("height", height);
+            svg.transition().delay(100).duration(100).attr("height", height);
 
-                expanded = false;
-            })();
+            expanded = false;
         }
     });
 };
@@ -183,7 +179,7 @@ var insert_stacked = function insert_stacked(target_selector, data, colors) {
         return yScale(d.y0 + d.y);
     });
 
-    svg.selectAll(".layer").data(layers).enter().append("path").attr("class", "layer").attr("d", function (d) {
+    svg.selectAll(".d3kk-layer").data(layers).enter().append("path").attr("class", "d3kk-layer").attr("d", function (d) {
         return area(d.values);
     }).style("fill", function (d, i) {
         return colors[i];
@@ -191,5 +187,5 @@ var insert_stacked = function insert_stacked(target_selector, data, colors) {
         return show_tooltip(d.key);
     });
 
-    svg.append("g").attr("class", "axis").attr("transform", "translate(0," + height + ")").call(xAxis);
+    svg.append("g").attr("class", "d3kk-axis").attr("transform", "translate(0," + height + ")").call(xAxis);
 };

--- a/src/web_reports.py
+++ b/src/web_reports.py
@@ -95,7 +95,7 @@ def web_report_course(summary_path, stat_path, output_path, html_templates, cour
             <div id="{question_id}" class="question">
                 <h4>{question_label}: {question}</h4>
                 <p>{average_label}: {average}</p>
-                <div id="{chart_id}" class="chart"></div>
+                <div id="{chart_id}" class="d3kk-chart"></div>
             </div>
         '''.format(
             question_id=question_id,


### PR DESCRIPTION
Fixes #76

Class names like `tooltip` could (and did) cause CSS conflict when included in a website that has its own CSS. To avoid problems with this, add a prefix to classes used by D3-kk.